### PR TITLE
Fix #7 Invalid SPDX generated when config file is not found

### DIFF
--- a/parser/config.go
+++ b/parser/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strings"
+	"os"
 
 	"github.com/spdx/tools-golang/builder"
 	"gopkg.in/yaml.v3"
@@ -103,7 +104,8 @@ func readConfFile(file string) []byte {
 	conf, err := ioutil.ReadFile(file)
 
 	if err != nil {
-		fmt.Println("failed reading yaml file\n", err)
+		fmt.Println("Error: failed reading yaml file. SPDX document not generated.\n")
+		os.Exit(1)
 	}
 	return conf
 }


### PR DESCRIPTION
Fix #7 Invalid SPDX generated when config file is not found

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>