### PR TITLE
Make SPDX version configurable

### DIFF
--- a/config/example_config.json
+++ b/config/example_config.json
@@ -13,5 +13,8 @@
     "packageLicenseDeclared": "license, licenseRef or NOASSERTION",
     "packageCopyrightText": "text or NOASSERTION",
     "packageSupplier": "Organization or recognized author of product. Optional",
-    "packageComment": "<text>Any relevant comment</text>. Optional"
+    "packageComment": "<text>Any relevant comment</text>. Optional",
+    "namespacePrefix": "https://spdx.org/spdxdocs/",
+    "creator":         "sbom-composer-v0.1",
+    "creatorType":     "Tool"
 }

--- a/config/example_config.json
+++ b/config/example_config.json
@@ -1,4 +1,5 @@
 {
+    "spdxVersion": "SPDX-2.2",
     "documentName": "composed-1.0",
     "packageName": "top-level-artifact",
     "spdxID": "SPDXRef-composed-sbom-product",

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -26,3 +26,11 @@ packageCopyrightText: ""
 packageSupplier: "Example supplier"
 # <text>Any relevant comment</text>. Optional
 packageComment: "<text>Example comment</text>"
+
+# The following fields belong to SPDX config reference
+# Prefix used for DocumentNamespace
+NamespacePrefix: "https://spdx.org/spdxdocs/"
+# Composed SPDX SBOM creator
+Creator:         "sbom-composer-v0.1"
+# Should be always set to "Tool"
+CreatorType:     "Tool"

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2022 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+# SPDX version the composed doc is output to
+spdxVersion: "SPDX-2.2"
 # SBOM-Composer report for <top level product name>
 documentName: "composed-1.0"
 # Top Level Composed SBOM product

--- a/parser/build.go
+++ b/parser/build.go
@@ -9,18 +9,24 @@ import (
 	"github.com/spdx/tools-golang/builder"
 )
 
-func Build(spdxVersion string, dirRoot string, conf *Config) (*Document, error) {
-	spdxDocRef := BuildVersion(spdxVersion, dirRoot, conf)
+func Build(dirRoot string, conf *Config) (*Document, error) {
+	spdxDocRef := BuildVersion(dirRoot, conf)
 
-	UpdatePackages(SPDX_VERSION, &spdxDocRef, conf)
+	UpdatePackages(&spdxDocRef, conf)
 	doc := CreateDocument(&spdxDocRef, conf)
 	return doc, nil
 }
 
-func BuildVersion(spdxVersion string, dirRoot string, conf *Config) SPDXDocRef {
+func BuildVersion(dirRoot string, conf *Config) SPDXDocRef {
 	res := SPDXDocRef{}
-	switch spdxVersion {
-	case "2.2":
+	switch conf.SPDXVersion {
+	case "SPDX-2.2":
+		var err error
+		res.Doc2_2, err = builder.Build2_2(conf.PackageName, dirRoot, conf.SPDXConfigRef)
+		if err != nil {
+			fmt.Printf("error while building spdx document reference for path %v with config %v, %v: %v\n", dirRoot, conf.PackageName, conf.SPDXConfigRef, err)
+		}
+	default:
 		var err error
 		res.Doc2_2, err = builder.Build2_2(conf.PackageName, dirRoot, conf.SPDXConfigRef)
 		if err != nil {
@@ -33,7 +39,7 @@ func BuildVersion(spdxVersion string, dirRoot string, conf *Config) SPDXDocRef {
 func GenerateComposedDoc(dirRoot string, output string, outFormat string, confFile string) error {
 	conf := LoadConfig(confFile)
 
-	doc, err := Build(SPDX_VERSION, dirRoot, conf)
+	doc, err := Build(dirRoot, conf)
 	if err != nil {
 		return err
 	}

--- a/parser/build.go
+++ b/parser/build.go
@@ -22,13 +22,13 @@ func BuildVersion(dirRoot string, conf *Config) SPDXDocRef {
 	switch conf.SPDXVersion {
 	case "SPDX-2.2":
 		var err error
-		res.Doc2_2, err = builder.Build2_2(conf.PackageName, dirRoot, conf.SPDXConfigRef)
+		res.Doc2_2, err = builder.Build2_2(conf.PackageName, dirRoot, conf.SPDXConfigRef.Conf2_2)
 		if err != nil {
 			fmt.Printf("error while building spdx document reference for path %v with config %v, %v: %v\n", dirRoot, conf.PackageName, conf.SPDXConfigRef, err)
 		}
 	default:
 		var err error
-		res.Doc2_2, err = builder.Build2_2(conf.PackageName, dirRoot, conf.SPDXConfigRef)
+		res.Doc2_2, err = builder.Build2_2(conf.PackageName, dirRoot, conf.SPDXConfigRef.Conf2_2)
 		if err != nil {
 			fmt.Printf("error while building spdx document reference for path %v with config %v, %v: %v\n", dirRoot, conf.PackageName, conf.SPDXConfigRef, err)
 		}

--- a/parser/build_test.go
+++ b/parser/build_test.go
@@ -14,7 +14,8 @@ import (
 func TestGenerateComposedDoc(t *testing.T) {
 	fmt.Println("Testing Unmarshal JSON Config")
 	t.Run("Unmarshal Config:", func(t *testing.T) {
-		input := []byte(`documentName: "composed-1.0"
+		input := []byte(`spdxVersion: "SPDX-2.2"
+documentName: "composed-1.0"
 packageName: "top-level-artifact"
 spdxID: "SPDXRef-DOCUMENT"
 packageVersion: "1.0"
@@ -31,13 +32,13 @@ packageComment: "<text>somecomment</text>"`)
 		want := Document{
 			SPDXDocRef: &SPDXDocRef{
 				Doc2_2: &spdx.Document2_2{
-					SPDXVersion:       "SPDX-2.2",
 					DataLicense:       "CC0-1.0",
 					SPDXIdentifier:    "DOCUMENT",
 					DocumentName:      "top-level-artifact",
 					DocumentNamespace: "https://spdx.org/spdxdocs/top-level-artifact-",
 				}},
 			ConfigDataRef: &Config{
+				SPDXVersion:             "SPDX-2.2",
 				SPDXConfigRef:           SPDXConfigReference,
 				PackageName:             "top-level-artifact",
 				DocumentName:            "composed-1.0",
@@ -57,10 +58,10 @@ packageComment: "<text>somecomment</text>"`)
 		}
 
 		loadedConfig := createConfig(input)
-		doc, err := Build(SPDX_VERSION, "../example_data/micro_sboms/tag_value", loadedConfig)
+		doc, err := Build("../example_data/micro_sboms/tag_value", loadedConfig)
 		assert.Equal(t, nil, err)
 
-		assert.Equal(t, want.SPDXDocRef.Doc2_2.SPDXVersion, doc.SPDXDocRef.Doc2_2.SPDXVersion)
+		assert.Equal(t, want.ConfigDataRef.SPDXVersion, doc.SPDXDocRef.Doc2_2.SPDXVersion)
 		assert.Equal(t, want.SPDXDocRef.Doc2_2.DataLicense, doc.SPDXDocRef.Doc2_2.DataLicense)
 		assert.Equal(t, want.SPDXDocRef.Doc2_2.SPDXIdentifier, doc.SPDXDocRef.Doc2_2.SPDXIdentifier)
 		assert.Equal(t, want.SPDXDocRef.Doc2_2.DocumentName, doc.SPDXDocRef.Doc2_2.DocumentName)

--- a/parser/build_test.go
+++ b/parser/build_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/spdx/tools-golang/builder"
 	"github.com/spdx/tools-golang/spdx"
 	"github.com/stretchr/testify/assert"
 )
@@ -27,7 +28,10 @@ packageLicenseConcluded: "BSD-3-Clause"
 packageLicenseDeclared: "BSD-3-Clause"
 packageCopyrightText: ""
 packageSupplier: "somesupplier"
-packageComment: "<text>somecomment</text>"`)
+packageComment: "<text>somecomment</text>"
+namespacePrefix:  "https://spdx.org/spdxdocs/"
+creator: "sbom-composer-v0.1"
+creatorType: "Tool"`)
 
 		want := Document{
 			SPDXDocRef: &SPDXDocRef{
@@ -38,8 +42,14 @@ packageComment: "<text>somecomment</text>"`)
 					DocumentNamespace: "https://spdx.org/spdxdocs/top-level-artifact-",
 				}},
 			ConfigDataRef: &Config{
-				SPDXVersion:             "SPDX-2.2",
-				SPDXConfigRef:           SPDXConfigReference,
+				SPDXVersion: "SPDX-2.2",
+				SPDXConfigRef: SPDXConfigRef{
+					Conf2_2: &builder.Config2_2{
+						NamespacePrefix: "https://spdx.org/spdxdocs/",
+						CreatorType:     "Tool",
+						Creator:         "sbom-composer-1.0",
+					},
+				},
 				PackageName:             "top-level-artifact",
 				DocumentName:            "composed-1.0",
 				SPDXID:                  "SPDXRef-DOCUMENT",

--- a/parser/config.go
+++ b/parser/config.go
@@ -15,7 +15,7 @@ import (
 )
 
 // PackageChecksum is a unique identifier used to verify if all files
-// in the orginal package are unchanged, exluding SPDX documents.
+// in the original package are unchanged, excluding SPDX documents.
 // Should be generated with SHA256.
 type PackageChecksum struct {
 	SHA256 string
@@ -32,6 +32,10 @@ var SPDXConfigReference *builder.Config2_2 = &builder.Config2_2{
 // to create a composed document with.
 type Config struct {
 	SPDXConfigRef *builder.Config2_2
+
+	// SPDXVersion is a configuration for the
+	// version that should be used as an output
+	SPDXVersion string `json:"spdxVersion"`
 
 	// DocumentName is an SBOM-Composer report
 	// for <top level product name>

--- a/parser/config.go
+++ b/parser/config.go
@@ -22,16 +22,15 @@ type PackageChecksum struct {
 }
 
 var NOASSERTION string = "NOASSERTION"
-var SPDXConfigReference *builder.Config2_2 = &builder.Config2_2{
-	NamespacePrefix: "https://spdx.org/spdxdocs/", // TODO: move this to config
-	CreatorType:     "Tool",
-	Creator:         "sbom-composer-1.0", // TODO: automate taking the version
+
+type SPDXConfigRef struct {
+	Conf2_2 *builder.Config2_2
 }
 
 // Config is a collection of configuration settings for builder
 // to create a composed document with.
 type Config struct {
-	SPDXConfigRef *builder.Config2_2
+	SPDXConfigRef SPDXConfigRef
 
 	// SPDXVersion is a configuration for the
 	// version that should be used as an output
@@ -77,6 +76,15 @@ type Config struct {
 
 	// PackageComment is any relevant comment in a <text></text> section
 	PackageComment string `json:"packageComment,omitempty"`
+
+	// NamespacePrefix is a prefix used for DocumentNamespace
+	NamespacePrefix string `json:"namespacePrefix"`
+
+	// Creator is the composed SPDX SBOM creator
+	Creator string `json:"creator"`
+
+	// CreatorType refers to SPDX CreatorType field
+	CreatorType string `json:"creatorType"`
 }
 
 func UnmarshalJSONConfig(jsonData []byte) (*Config, error) {
@@ -115,9 +123,7 @@ func readConfFile(file string) []byte {
 }
 
 func createConfig(loadedData []byte) *Config {
-	conf := Config{}
-
-	conf.SPDXConfigRef = SPDXConfigReference
+	conf := &Config{}
 
 	mapData := make(map[string]interface{})
 
@@ -128,6 +134,8 @@ func createConfig(loadedData []byte) *Config {
 
 	dataByte, _ := json.Marshal(mapData)
 	_ = json.Unmarshal(dataByte, &conf)
+
+	conf = setSPDXConfigRef(conf)
 
 	if len(conf.PackageDownloadLocation) == 0 {
 		conf.PackageDownloadLocation = NOASSERTION
@@ -143,5 +151,27 @@ func createConfig(loadedData []byte) *Config {
 	}
 	conf.PackageChecksum.SHA256 = strings.Trim(conf.PackageChecksum.SHA256, "\"{}")
 
-	return &conf
+	return conf
+}
+
+func setSPDXConfigRef(conf *Config) *Config {
+	switch conf.SPDXVersion {
+	case "SPDX-2.2":
+		conf.SPDXConfigRef = SPDXConfigRef{
+			Conf2_2: &builder.Config2_2{
+				NamespacePrefix: conf.NamespacePrefix,
+				CreatorType:     conf.CreatorType,
+				Creator:         conf.Creator,
+			},
+		}
+	default:
+		conf.SPDXConfigRef = SPDXConfigRef{
+			Conf2_2: &builder.Config2_2{
+				NamespacePrefix: conf.NamespacePrefix,
+				CreatorType:     conf.CreatorType,
+				Creator:         conf.Creator,
+			},
+		}
+	}
+	return conf
 }

--- a/parser/config_test.go
+++ b/parser/config_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func generateJSONTConfigExample(documentName string, packageName string, spdxID string, packageVersion string,
+func generateJSONTConfigExample(spdxVersion string, documentName string, packageName string, spdxID string, packageVersion string,
 	packageDownloadLocation string, packageChecksum PackageChecksum, filesAnalyzed bool, packageLicenseConcluded string,
 	packageLicenseDeclared string, packageCopyrightText string, packageSupplier string, packageComment string) []byte {
-	jsonStr := fmt.Sprintf("{\"documentName\":\"%s\",\"packageName\":\"%s\",\"spdxID\":\"%s\",\"packageVersion\":\"%s\",\"packageDownloadLocation\":\"%s\",\"filesAnalyzed\":\"%t\",\"packageChecksum\":\"%s\", \"packageLicenseConcluded\":\"%s\", \"packageLicenseDeclared\":\"%s\", \"packageCopyrightText\":\"%s\", \"packageSupplier\":\"%s\", \"packageComment\":\"%s\"}",
-		documentName, packageName, spdxID, packageVersion, packageDownloadLocation, filesAnalyzed, packageChecksum,
+	jsonStr := fmt.Sprintf("{\"spdxVersion\":\"%s\",\"documentName\":\"%s\",\"packageName\":\"%s\",\"spdxID\":\"%s\",\"packageVersion\":\"%s\",\"packageDownloadLocation\":\"%s\",\"filesAnalyzed\":\"%t\",\"packageChecksum\":\"%s\", \"packageLicenseConcluded\":\"%s\", \"packageLicenseDeclared\":\"%s\", \"packageCopyrightText\":\"%s\", \"packageSupplier\":\"%s\", \"packageComment\":\"%s\"}",
+		spdxVersion, documentName, packageName, spdxID, packageVersion, packageDownloadLocation, filesAnalyzed, packageChecksum,
 		packageLicenseConcluded, packageLicenseDeclared, packageCopyrightText, packageSupplier, packageComment)
 
 	return []byte(jsonStr)
@@ -37,11 +37,12 @@ func TestUnmarshalJSONConfig(t *testing.T) {
 
 		pch := PackageChecksum{SHA256: checksum}
 
-		jsonData := generateJSONTConfigExample("composed-1.0", "top-level-artifact", "SPDXRef-DOCUMENT", "1.0", NOASSERTION, pch,
+		jsonData := generateJSONTConfigExample("SPDX-2.2", "composed-1.0", "top-level-artifact", "SPDXRef-DOCUMENT", "1.0", NOASSERTION, pch,
 			false, "BSD-3-Clause", "BSD-3-Clause", NOASSERTION,
 			"somesupplier", "somecomment")
 		conf, _ := UnmarshalJSONConfig(jsonData)
 
+		assert.Equal(t, "SPDX-2.2", conf.SPDXVersion)
 		assert.Equal(t, "composed-1.0", conf.DocumentName)
 		assert.Equal(t, "top-level-artifact", conf.PackageName)
 		assert.Equal(t, "SPDXRef-DOCUMENT", conf.SPDXID)

--- a/parser/document.go
+++ b/parser/document.go
@@ -29,9 +29,16 @@ func CreateDocumentWithSPDXRef() *Document {
 	return doc
 }
 
-func UpdatePackages(spdxVersion string, spdxDocRef *SPDXDocRef, conf *Config) {
-	switch spdxVersion {
-	case "2.2":
+func UpdatePackages(spdxDocRef *SPDXDocRef, conf *Config) {
+	switch conf.SPDXVersion {
+	case "SPDX-2.2":
+		for i := range spdxDocRef.Doc2_2.Packages {
+			if spdxDocRef.Doc2_2.Packages[i].PackageName == conf.PackageName &&
+				len(spdxDocRef.Doc2_2.Packages[i].PackageVersion) == 0 {
+				spdxDocRef.Doc2_2.Packages[i].PackageVersion = conf.PackageVersion
+			}
+		}
+	default:
 		for i := range spdxDocRef.Doc2_2.Packages {
 			if spdxDocRef.Doc2_2.Packages[i].PackageName == conf.PackageName &&
 				len(spdxDocRef.Doc2_2.Packages[i].PackageVersion) == 0 {

--- a/parser/read_config_test.go
+++ b/parser/read_config_test.go
@@ -15,7 +15,8 @@ func TestLoadConfigYAML(t *testing.T) {
 	t.Run("Loading YAML Config:", func(t *testing.T) {
 
 		conf := LoadConfig("../config/example_config.yaml")
-		fmt.Println(conf)
+
+		assert.Equal(t, "SPDX-2.2", conf.SPDXVersion)
 		assert.Equal(t, "composed-1.0", conf.DocumentName)
 		assert.Equal(t, "top-level-artifact", conf.PackageName)
 		assert.Equal(t, "SPDXRef-DOCUMENT", conf.SPDXID)


### PR DESCRIPTION
This change abstracts the tools-golang SPDX version references to make possible an easier version switch. Leaving the PR open until [tools-golang#172](https://github.com/spdx/tools-golang/pull/172) gets merged, as with its changes the SPDXv2.3  upgrade would be much more clean.

Covers #5, #6 and #13.